### PR TITLE
Remove version from Gradle build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 group 'com.verificationgentleman'
-version = '1.2.2'
 
 sourceSets {
     main {


### PR DESCRIPTION
Since this project is mostly consumed as a source dependency, the version is configured using the Git tag. Setting the version in the build script is fragile, as we have to not forget to update it.